### PR TITLE
Fix GetKerning by overriding Equals and GetHashCode

### DIFF
--- a/src/Cyotek.Drawing.BitmapFont/Kerning.cs
+++ b/src/Cyotek.Drawing.BitmapFont/Kerning.cs
@@ -6,12 +6,14 @@
  * Licensed under the MIT License. See license.txt for the full text.
  */
 
+using System;
+
 namespace Cyotek.Drawing.BitmapFont
 {
   /// <summary>
   /// Represents the font kerning between two characters.
   /// </summary>
-  public struct Kerning
+  public struct Kerning : IEquatable<Kerning>
   {
     #region Constructors
 
@@ -87,6 +89,18 @@ namespace Cyotek.Drawing.BitmapFont
       if (obj.GetType() != typeof(Kerning)) return false;
       Kerning k = (Kerning)obj;
       return FirstCharacter == k.FirstCharacter && SecondCharacter == k.SecondCharacter;
+    }
+
+    /// <summary>
+    /// Check if the other kerning is between the same two characters.
+    /// </summary>
+    /// <param name="other"></param>
+    /// <returns>
+    /// Whether or not the other kerning is between the same two characters.
+    /// </returns>
+    public bool Equals(Kerning other)
+    {
+      return Equals(other);
     }
 
     /// <summary>

--- a/src/Cyotek.Drawing.BitmapFont/Kerning.cs
+++ b/src/Cyotek.Drawing.BitmapFont/Kerning.cs
@@ -73,6 +73,35 @@ namespace Cyotek.Drawing.BitmapFont
     {
       return string.Format("{0} to {1} = {2}", this.FirstCharacter, this.SecondCharacter, this.Amount);
     }
+    
+    /// <summary>
+    /// Check if the object represents kerning between the same two characters.
+    /// </summary>
+    /// <param name="obj"></param>
+    /// <returns>
+    /// Whether or not the object represents kerning between the same two characters.
+    /// </returns>
+    public override bool Equals(object obj)
+    {
+      if (obj == null) return false;
+      if (obj.GetType() != typeof(Kerning)) return false;
+      Kerning k = (Kerning)obj;
+      return FirstCharacter == k.FirstCharacter && SecondCharacter == k.SecondCharacter;
+    }
+
+    /// <summary>
+    /// Return the hash code of the kerning between the two characters.
+    /// </summary>
+    /// <returns>
+    /// A unique hash code of the kerning between the two characters.
+    /// </returns>
+    public override int GetHashCode()
+    {
+      unchecked
+      {
+        return (FirstCharacter << 16) | SecondCharacter;
+      }
+    }
 
     #endregion
   }


### PR DESCRIPTION
See https://github.com/ppy/osu-framework/issues/465

This PR overrides Equals and GetHashCode in Kerning so that the dictionary lookup in GetKerning works appropriately. This would also fixes the duplicate Kerning check in LoadText.

The alternative was to store a tuple of first and second characters in the dictionary, but then would've made the Kerning class obsolete.

Let me know what you think!