### PR TITLE
Fixed Split method to prevent exception in case page file name contai…

### DIFF
--- a/src/BitmapFontLoader.cs
+++ b/src/BitmapFontLoader.cs
@@ -373,6 +373,11 @@ namespace Cyotek.Drawing.BitmapFont
         if (hasQuotes)
         {
           partEnd = s.IndexOf(delimiter, quoteEnd + 1);
+
+          if (partEnd == -1)
+          {
+            partEnd = s.Length;
+          }
         }
 
         length = partEnd - partStart - 1;


### PR DESCRIPTION
Fixed Split method to prevent exception in case when page file name contains space - for example, "IndexOutOfRange" exception is thrown when Split method is called with the following string:
page id=0 file="default font_0.png"